### PR TITLE
Update background color of the root node

### DIFF
--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/Command.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/Command.kt
@@ -19,4 +19,8 @@ public sealed class Command {
     public data class RemoveNode(
         val id: String,
     ) : Command()
+
+    public data class UpdateRootBackgroundColor(
+        val colorInHex: String,
+    ) : Command()
 }

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/JujubaCommander.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/JujubaCommander.kt
@@ -33,6 +33,12 @@ public class JujubaCommander {
                     concat(command.id) + "remove();"
                 )
             }
+
+            is Command.UpdateRootBackgroundColor -> {
+                _state.emit(
+                    "document.body.style.backgroundColor=\'${command.colorInHex}\';"
+                )
+            }
         }
     }
 

--- a/jujubasvg/src/test/kotlin/com/gabrielbmoro/jujubasvg/core/commander/JujubaCommanderTest.kt
+++ b/jujubasvg/src/test/kotlin/com/gabrielbmoro/jujubasvg/core/commander/JujubaCommanderTest.kt
@@ -64,4 +64,17 @@ class JujubaCommanderTest {
             val result = commander.state.value
             assertEquals(jsCommand, result)
         }
+
+    @Test
+    fun `given a change root background color command when it is invoked then emit the right jsCommand`() =
+        runTest {
+            val jsCommand = "document.body.style.backgroundColor='#000000';"
+            val commander = JujubaCommander()
+
+            commander.execute(Command.UpdateRootBackgroundColor("#000000"))
+            advanceUntilIdle()
+
+            val result = commander.state.value
+            assertEquals(jsCommand, result)
+        }
 }


### PR DESCRIPTION
# Update background color of the root node

## Description 📑
New command to update the background color of the root node.

--

## Issues 🔖
- Issue 01 -> https://github.com/gabrielbmoro/jujubaSVG/issues/16
--
