### PR TITLE
Change colorInHex: String to color: Color

### DIFF
--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/Const.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/Const.kt
@@ -6,6 +6,5 @@ public object Const {
     internal const val MIME_TYPE = "text/html"
     internal const val ENCONDING = "utf-8"
     internal const val BASE_INTERFACE_NAME = "JujubaInterface"
-    internal const val DEFAULT_ROOT_BACKGROUND_COLOR_IN_HEX = "#FFFFFF"
     internal const val TAG = "JujubaSVG"
 }

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/JujubaSVG.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/JujubaSVG.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import com.gabrielbmoro.jujubasvg.core.bridge.JujubaSVGWebInterface
@@ -34,7 +35,7 @@ public fun JujubaSVG(
     @RawRes svgRawRes: Int,
     commander: JujubaCommander,
     onElementClick: (NodeInfo) -> Unit,
-    backgroundColorInHex: String = Const.DEFAULT_ROOT_BACKGROUND_COLOR_IN_HEX,
+    backgroundColor: Color = Color.White,
     modifier: Modifier
 ) {
     val resources = LocalContext.current.resources
@@ -48,7 +49,7 @@ public fun JujubaSVG(
             commander = commander,
             onElementClick = onElementClick,
             modifier = modifier,
-            backgroundColorInHex = backgroundColorInHex
+            backgroundColor = backgroundColor
         )
     }
 
@@ -65,7 +66,7 @@ public fun JujubaSVG(
     svgText: String,
     commander: JujubaCommander,
     onElementClick: (NodeInfo) -> Unit,
-    backgroundColorInHex: String = Const.DEFAULT_ROOT_BACKGROUND_COLOR_IN_HEX,
+    backgroundColor: Color = Color.White,
     modifier: Modifier
 ) {
     val context = LocalContext.current
@@ -149,7 +150,7 @@ public fun JujubaSVG(
         if (isWebViewReady) {
             commander.execute(
                 Command.UpdateRootBackgroundColor(
-                    backgroundColorInHex
+                    backgroundColor
                 )
             )
         }

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/Command.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/Command.kt
@@ -1,5 +1,6 @@
 package com.gabrielbmoro.jujubasvg.core.commander
 
+import androidx.compose.ui.graphics.Color
 import com.gabrielbmoro.jujubasvg.model.NodeCoordinate
 
 public sealed class Command {
@@ -7,21 +8,21 @@ public sealed class Command {
     /**
      * Update the background color of a node.
      * @param id The id of the node.
-     * @param colorInHex The color in hex.
+     * @param color The color in hex.
      */
     public data class UpdateBackgroundColor(
         val id: String,
-        val colorInHex: String,
+        val color: Color,
     ) : Command()
 
     /**
      * Update the stroke color of a node.
      * @param id The id of the node.
-     * @param colorInHex The color in hex.
+     * @param color The color in hex.
      */
     public data class UpdateStrokeColor(
         val id: String,
-        val colorInHex: String,
+        val color: Color,
     ) : Command()
 
     /**
@@ -46,7 +47,7 @@ public sealed class Command {
      * Update the root background color.
      */
     public data class UpdateRootBackgroundColor(
-        val colorInHex: String,
+        val color: Color,
     ) : Command()
 
     /**

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/Command.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/Command.kt
@@ -8,7 +8,7 @@ public sealed class Command {
     /**
      * Update the background color of a node.
      * @param id The id of the node.
-     * @param color The color in hex.
+     * @param color The color for the background.
      */
     public data class UpdateBackgroundColor(
         val id: String,
@@ -18,7 +18,7 @@ public sealed class Command {
     /**
      * Update the stroke color of a node.
      * @param id The id of the node.
-     * @param color The color in hex.
+     * @param color The color for the stroke.
      */
     public data class UpdateStrokeColor(
         val id: String,

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/JujubaCommander.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/commander/JujubaCommander.kt
@@ -2,6 +2,7 @@ package com.gabrielbmoro.jujubasvg.core.commander
 
 import android.util.Log
 import com.gabrielbmoro.jujubasvg.core.Const.TAG
+import com.gabrielbmoro.jujubasvg.core.ext.toHex
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -23,11 +24,11 @@ public class JujubaCommander {
     private fun convertToJSCode(command: Command): String {
         return when (command) {
             is Command.UpdateBackgroundColor -> {
-                "updateBackgroundColor(\'${command.id}\',\'${command.colorInHex}\');"
+                "updateBackgroundColor(\'${command.id}\',\'${command.color.toHex()}\');"
             }
 
             is Command.UpdateStrokeColor -> {
-                "updateStrokeColor(\'${command.id}\',\'${command.colorInHex}\');"
+                "updateStrokeColor(\'${command.id}\',\'${command.color.toHex()}\');"
             }
 
             is Command.UpdateStrokeWidth -> {
@@ -39,7 +40,7 @@ public class JujubaCommander {
             }
 
             is Command.UpdateRootBackgroundColor -> {
-                "updateRootBackgroundColor(\'${command.colorInHex}\');"
+                "updateRootBackgroundColor(\'${command.color.toHex()}\');"
             }
 
             is Command.AddRoundedImage -> {

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/ext/CommandExt.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/ext/CommandExt.kt
@@ -1,0 +1,17 @@
+package com.gabrielbmoro.jujubasvg.core.ext
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+
+/**
+ * Transform a Compose color to hexadecimal following this pattern:'#ffffff.
+ * @param id The id of the node.
+ * @param color The color in hex.
+ */
+@OptIn(ExperimentalStdlibApi::class)
+public fun Color.toHex(): String {
+    return "#" + this
+        .toArgb()
+        .toHexString()
+        .substring(2)
+}

--- a/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/ext/CommandExt.kt
+++ b/jujubasvg/src/main/kotlin/com/gabrielbmoro/jujubasvg/core/ext/CommandExt.kt
@@ -4,14 +4,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 
 /**
- * Transform a Compose color to hexadecimal following this pattern:'#ffffff.
- * @param id The id of the node.
- * @param color The color in hex.
+ * Transforms a Compose Color into a hexadecimal String following the pattern "#ffffff".
  */
-@OptIn(ExperimentalStdlibApi::class)
-public fun Color.toHex(): String {
-    return "#" + this
-        .toArgb()
-        .toHexString()
-        .substring(2)
+internal fun Color.toHex(): String {
+    val argb = this.toArgb()
+    return buildString {
+        append('#')
+        append(Integer.toHexString((argb shr 16) and 0xFF).padStart(2, '0')) // alpha
+        append(Integer.toHexString((argb shr 8) and 0xFF).padStart(2, '0'))  // red
+        append(Integer.toHexString(argb and 0xFF).padStart(2, '0'))          // green
+        append(Integer.toHexString((argb shr 24) and 0xFF).padStart(2, '0')) // blue
+    }
 }
+

--- a/jujubasvg/src/main/res/raw/base_js.js
+++ b/jujubasvg/src/main/res/raw/base_js.js
@@ -2,14 +2,14 @@ function _getJujubaNodeById(elementId) {
     return document.getElementsByTagName('svg')[0].getElementById(elementId);
 }
 
-function updateBackgroundColor(elementId, colorInHex) {
+function updateBackgroundColor(elementId, color) {
     const node = _getJujubaNodeById(elementId);
-    node.style.fill = colorInHex;
+    node.style.fill = color;
 }
 
-function updateStrokeColor(elementId, colorInHex) {
+function updateStrokeColor(elementId, color) {
     const node = _getJujubaNodeById(elementId);
-    node.style.stroke = colorInHex;
+    node.style.stroke = color;
 }
 
 function updateStrokeWidth(elementId, widthInPx) {
@@ -22,8 +22,8 @@ function removeNode(elementId) {
     node.remove();
 }
 
-function updateRootBackgroundColor(colorInHex) {
-    document.body.style.backgroundColor = colorInHex;
+function updateRootBackgroundColor(color) {
+    document.body.style.backgroundColor = color;
 }
 
 function addRoundedImage(elementId, imageId, url, width, height, x, y) {

--- a/sampleApp/src/main/kotlin/com/gabrielbmoro/moviedb/RootApp.kt
+++ b/sampleApp/src/main/kotlin/com/gabrielbmoro/moviedb/RootApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import com.gabrielbmoro.jujubasvg.core.JujubaSVG
 import com.gabrielbmoro.jujubasvg.core.commander.Command
 import com.gabrielbmoro.jujubasvg.core.rememberJujubaCommander
@@ -39,7 +40,7 @@ internal fun RootApp() {
                 }
             },
             commander = jujubaCommander,
-            backgroundColorInHex = "#ffb700",
+            backgroundColor = Color(0xffffb700),
             modifier = Modifier.fillMaxSize()
         )
     }


### PR DESCRIPTION
# Change
- colorInHex: String 
to 
- color: Color

### I changed the parameter for some reasons:

The consumer of the PR is baaaasically a Kotlin Jetpack Compose dev so they should feel more "comfortable". I Personally prefer to write sum "Color.Raticate" rather than "#ratata" myself.

What do you think?

P.S.: I could have written the ext function like this:
```
public fun Color.toHex(): String {
    return "#" + this
        .toArgb()
        .toHexString()
        .substring(2)
}
```

but the current one is better performance wise because .substring creates another String under the hood. "shr" and "and" are crazy ass bit manipulations :P