### PR TITLE
feat: update Gradle configuration for Maven publishing and add GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-android:
+  publish-kmp:
     name: Publish
     runs-on: ubuntu-latest
 

--- a/kotlin/jujubasvg/build.gradle.kts
+++ b/kotlin/jujubasvg/build.gradle.kts
@@ -3,7 +3,6 @@ import java.util.Properties
 
 plugins {
     id("plugins.kmp-library-plugin")
-    id("maven-publish")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jetbrains.compose)
     alias(libs.plugins.vanniktech.maven.publish)
@@ -54,7 +53,9 @@ val versionPublish: String = versionProperties.getProperty("VERSION")
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-    signAllPublications()
+    if (System.getenv("ORG_GRADLE_PROJECT_signingInMemoryKeyId") != null) {
+        signAllPublications()
+    }
 
     coordinates(
         project.property("GROUP_ID") as String,
@@ -63,9 +64,9 @@ mavenPublishing {
     )
 
     pom {
-        name.set(project.property("ARTIFACT_ID") as String)
-        description.set(project.property("ARTIFACT_ID") as String)
-        inceptionYear.set("2024")
+        name.set(project.property("POM_NAME") as String)
+        description.set(project.property("POM_DESCRIPTION") as String)
+        inceptionYear.set(project.property("POM_INCEPTION_YEAR") as String)
         url.set(project.property("POM_URL") as String)
 
         licenses {
@@ -75,8 +76,8 @@ mavenPublishing {
             }
         }
         scm {
-            connection.set("scm:git@github.com:CodandoTV/jujubaSVG.git")
-            url.set("https://github.com/CodandoTV/jujubaSVG.git")
+            connection.set(project.property("POM_SCM_CONNECTION") as String)
+            url.set(project.property("POM_SCM_URL") as String)
         }
         developers {
             developer {

--- a/kotlin/jujubasvg/gradle.properties
+++ b/kotlin/jujubasvg/gradle.properties
@@ -5,11 +5,10 @@ kotlin.code.style=official
 
 GROUP_ID=io.github.codandotv
 POM_NAME=jujubaSvg
-POM_DESCRIPTION=A small library to help you handle SVG files on Android.
+POM_DESCRIPTION=A small Kotlin Multiplatform library to help you handle SVG files
 POM_INCEPTION_YEAR=2024
 POM_URL=https://github.com/CodandoTV/jujubaSVG/
 ARTIFACT_ID=jujubaSVG
-VERSION=1.1.0
 
 POM_LICENSE_NAME=MIT License
 POM_LICENSE_URL=https://opensource.org/license/mit
@@ -18,3 +17,6 @@ POM_DEVELOPER_ID=CodandoTV
 POM_DEVELOPER_NAME=CodandoTV
 POM_DEVELOPER_URL=https://github.com/CodandoTV/
 POM_DEVELOPER_EMAIL=codando.tv@gmail.com
+
+POM_SCM_CONNECTION=scm:git@github.com:CodandoTV/jujubaSVG.git
+POM_SCM_URL=https://github.com/CodandoTV/jujubaSVG.git


### PR DESCRIPTION
## Summary
Updated the Gradle configuration in the Kotlin library to support Maven publishing and added a GitHub Actions workflow for automated releases. The existing `publish-android.yml` workflow was renamed to `publish.yml`.

## Changed Files
- `.github/workflows/publish.yml` (renamed from publish-android.yml)
- `kotlin/jujubasvg/build.gradle.kts`
- `kotlin/jujubasvg/gradle.properties`