### PR TITLE
docs: update documentation files and rename setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Welcome to the jujubaSVG library! A CodandoTV library 👋
 
-jujubaSVG is a user-friendly library for handling SVG files in Android and Flutter applications. It enables granular manipulation of SVG elements - you can access any element by its ID to modify properties like background color, stroke, and other attributes.
+jujubaSVG is a user-friendly library for handling SVG files in Kotlin (Compose Multiplatform) and Flutter applications. It enables granular manipulation of SVG elements - you can access any element by its ID to modify properties like background color, stroke, and other attributes.
 
 <p align="center">
   <img src="img/jujuba_icon.png" width="200" height="200" alt="Logo">
@@ -24,7 +24,7 @@ jujubaSVG is a user-friendly library for handling SVG files in Android and Flutt
 
 ## How to use? 🤔
 
-### Android
+### Kotlin (Compose Multiplatform)
 
 You need to add the following line in your desired `module/build.gradle.kts`:
 
@@ -113,7 +113,7 @@ The library provides a widget called `JujubaSVGWidget`, there you can the `comma
 
 ## Sample project
 
-### Android
+### Kotlin
 
 More details you can check at our [sample project](kotlin/androidSampleApp)
 
@@ -137,7 +137,7 @@ More details you can check at our [sample project](kotlin/androidSampleApp)
 - JDK 17+
 - Gradle 9.3.1+
 - Android Gradle Plugin 9.1.0+
-- Android API 22+
+- Android API 23+
 
 ### Flutter Package
 

--- a/docs/available-commands.md
+++ b/docs/available-commands.md
@@ -2,7 +2,7 @@
 
 jujubaSVG already provides some commands. This page we will demonstrate how to use them in Kotlin and Dart (Flutter).
 
-!!!tip "Support added - Android v1.3.0 / Flutter v1.1.0"
+!!!tip "Support added — Kotlin v1.3.0+ (KMP from v1.4.0) / Flutter v1.1.0+"
 
 ## Custom command
 
@@ -149,7 +149,7 @@ Add a rounded image into the same parent of the elementId.
 ```kotlin
 // KOTLIN
 jujubaCommander.execute(
-    AddRoundedImage(
+    Command.AddRoundedImage(
         elementId = nodeInfo.id,
         imageId = "imageId",
         imageUrl = "https://i.imgur.com/LQIsf.jpeg",

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,9 @@
 
 ![JujubaSVG logo](./img/jujuba_icon.png)
 
-jujubaSVG is a user-friendly library for handling SVG files in Android and Flutter applications. It enables granular manipulation of SVG elements - you can access any element by its ID to modify properties like background color, stroke, and other attributes.
+jujubaSVG is a user-friendly library for handling SVG files in Kotlin (Compose Multiplatform) and Flutter applications. It enables granular manipulation of SVG elements - you can access any element by its ID to modify properties like background color, stroke, and other attributes.
 
-**Minimum requirements:** Kotlin 2.4.0+ / JDK 17+ / Gradle 9.3.1+ / AGP 9.1.0+ / Android API 22+ / Dart ^3.5.0+
+**Minimum requirements:** Kotlin 2.4.0+ / JDK 17+ / Gradle 9.3.1+ / AGP 9.1.0+ / Android API 23+ / Dart ^3.5.0+
 
 Take a look at our [repository](https://github.com/CodandoTV/jujubaSVG).
 
@@ -15,7 +15,7 @@ Take a look at our [repository](https://github.com/CodandoTV/jujubaSVG).
 
 ### 1. Setup
 
-- [Android](./setup/android.md)
+- [Kotlin](./setup/kotlin.md)
 
 - [Flutter](./setup/flutter.md)
 

--- a/docs/setup/kotlin.md
+++ b/docs/setup/kotlin.md
@@ -1,4 +1,4 @@
-# Android
+# Kotlin (Compose Multiplatform)
 
 ## Minimum Requirements
 
@@ -6,7 +6,8 @@
 - JDK 17+
 - Gradle 9.3.1+
 - Android Gradle Plugin 9.1.0+
-- Android API 22+
+- Android API 23+
+- Compose Multiplatform support from v1.4.0
 
 ## 1. Add the Dependency
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,7 @@ theme:
 
 nav:
   - Setup ✨:
-    - Android: setup/android.md
+    - Kotlin: setup/kotlin.md
     - Flutter: setup/flutter.md
   - Available Commands 📐: available-commands.md
   - Contributions 🤝: contributions.md


### PR DESCRIPTION
## Summary

Update README, restructure documentation index, and rename the setup guide from `android.md` to `kotlin.md` to reflect Kotlin Multiplatform support.

## Changed Files
- `README.md` — link and description updates
- `docs/available-commands.md` — minor copy edits
- `docs/index.md` — restructured content
- `docs/setup/android.md` → `docs/setup/kotlin.md` — renamed and updated
- `mkdocs.yml` — updated nav reference